### PR TITLE
Splinter tests - improved visibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_script:
   - psql -c 'create database magnetism;' -U postgres
   - ./travis_db_setup.sh
 script:
-  - pytest
+  - pytest -r A
 after_script:
   - pkill python3

--- a/geckodriver.log
+++ b/geckodriver.log
@@ -407,3 +407,143 @@ console.error: BroadcastService:
   Stack:
     remoteSettingsFunction/remoteSettings.pollChanges@resource://services-settings/remote-settings.js:750:13
 
+1557914626754	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.OuzZ7m1gYf7f"
+*** You are running in headless mode.
+1557914627730	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557914627730	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557914630075	Marionette	INFO	Listening on port 54017
+1557914630180	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557914630594	Marionette	INFO	Stopped listening on port 54017
+1557915007700	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.hKV4bJWwyaeN"
+*** You are running in headless mode.
+1557915008402	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915008402	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915010673	Marionette	INFO	Listening on port 54140
+1557915010693	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915027685	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.elSNgYClrj7A"
+*** You are running in headless mode.
+1557915028861	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915028861	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915031361	Marionette	INFO	Listening on port 54192
+1557915031404	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915031808	Marionette	INFO	Stopped listening on port 54192
+1557915094534	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.0adjRXqCULv4"
+*** You are running in headless mode.
+1557915095053	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915095053	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915097078	Marionette	INFO	Listening on port 54257
+1557915097108	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915097542	Marionette	INFO	Stopped listening on port 54257
+JavaScript error: resource://devtools-client-shared/components/reps/reps.js, line 6161: TypeError: __webpack_require__(...) is undefined
+JavaScript error: resource://gre/modules/Sqlite.jsm, line 841: Error: Connection is not open.
+1557915118476	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.JEJzdX1ApQbw"
+*** You are running in headless mode.
+1557915119088	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915119089	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915121109	Marionette	INFO	Listening on port 54302
+1557915121144	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915121610	Marionette	INFO	Stopped listening on port 54302
+1557915146381	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.VIfTfEbQjsag"
+*** You are running in headless mode.
+1557915146953	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915146959	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915149054	Marionette	INFO	Listening on port 54348
+1557915149154	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915149543	Marionette	INFO	Stopped listening on port 54348
+JavaScript error: resource://devtools-client-shared/components/reps/reps.js, line 6161: TypeError: __webpack_require__(...) is undefined
+1557915327662	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.3Ye4yi40ZjlA"
+*** You are running in headless mode.
+1557915328423	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915328423	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915330664	Marionette	INFO	Listening on port 54410
+1557915330765	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915331165	Marionette	INFO	Stopped listening on port 54410
+1557915362181	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.gRmXLSF91tAi"
+*** You are running in headless mode.
+1557915362703	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915362703	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915364730	Marionette	INFO	Listening on port 54461
+1557915364764	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915365151	Marionette	INFO	Stopped listening on port 54461
+1557915411464	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.IsRboVmrc7Sc"
+*** You are running in headless mode.
+1557915412012	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915412012	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915414037	Marionette	INFO	Listening on port 54506
+1557915414141	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915414566	Marionette	INFO	Stopped listening on port 54506
+1557915520357	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.JpguG5RG7iK9"
+*** You are running in headless mode.
+1557915520875	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915520875	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915522907	Marionette	INFO	Listening on port 54560
+1557915522940	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915523430	Marionette	INFO	Stopped listening on port 54560
+JavaScript error: resource://devtools-client-jsonview/lib/require.js, line 166: Error: Script error for: devtools/client/shared/vendor/redux
+http://requirejs.org/docs/errors.html#scripterror
+1557915525024	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.yFyxwjBj3PBy"
+*** You are running in headless mode.
+1557915525549	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915525550	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915527593	Marionette	INFO	Listening on port 54606
+1557915527616	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915586438	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.OjLtz2urllJa"
+*** You are running in headless mode.
+1557915586978	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915586979	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915589382	Marionette	INFO	Listening on port 54655
+1557915589445	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915590018	Marionette	INFO	Stopped listening on port 54655
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+1557915591842	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.7cYCzqQW3CCm"
+*** You are running in headless mode.
+1557915592531	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915592532	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915594703	Marionette	INFO	Listening on port 54705
+1557915594726	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915630307	mozrunner::runner	INFO	Running command: "/Applications/Firefox.app/Contents/MacOS/firefox-bin" "-marionette" "-foreground" "-no-remote" "-profile" "/var/folders/yl/0jbssmhd06s7mq8sl8r2x44r0000gq/T/rust_mozprofile.jB7GV9fQMe01"
+*** You are running in headless mode.
+1557915631040	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: resource://pdf.js/
+1557915631043	addons.webextension.screenshots@mozilla.org	WARN	Loading extension 'screenshots@mozilla.org': Reading manifest: Invalid host permission: about:reader*
+1557915633396	Marionette	INFO	Listening on port 54756
+1557915633407	Marionette	WARN	TLS certificate errors will be ignored for this session
+1557915633935	Marionette	INFO	Stopped listening on port 54756
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+
+IPDL protocol error: Handler returned error code!
+
+###!!! [Parent][DispatchAsyncMessage] Error: PLayerTransaction::Msg_ReleaseLayer Processing error: message was deserialized, but the handler returned false (indicating failure)
+

--- a/tests/test_controller_feature.py
+++ b/tests/test_controller_feature.py
@@ -1,15 +1,11 @@
-# import flask
-
 from splinter import Browser
-browser = Browser('firefox', headless="true")
 
-# def test_topics():
+def test_topics():
 
-browser.visit('http://localhost:5000/topics/add')
-browser.visit('http://localhost:5000/topics')
+    browser = Browser('firefox', headless="true")
 
-assert browser.is_text_present('Physics')
-# assert browser.is_text_present('URL')
+    browser.visit('http://localhost:5000/topics/add')
+    browser.visit('http://localhost:5000/topics')
+    assert browser.is_text_present('Physics')
 
-
-browser.quit()
+    browser.quit()


### PR DESCRIPTION
Amended feature test to show visibility of test results by putting the full test within a test_ method
Amended Travis to produce a test summary of tests

The -r options accepts a number of characters after it, with a used above meaning “all except passes”.

Here is the full list of available characters that can be used:

f - failed
E - error
s - skipped
x - xfailed
X - xpassed
p - passed
P - passed with output
a - all except pP
A - all