### PR TITLE
Added route to API for giving feedback rating

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ This script is api router it:
 """
 
 import os
-from flask import Flask, jsonify, render_template
+from flask import Flask, jsonify, render_template, request, json
 from api.config import app_config
 
 from flask_sqlalchemy import SQLAlchemy
@@ -35,7 +35,7 @@ def topics():
         response.headers.add('Access-Control-Allow-Origin', '*')
         return response
     except Exception as error:
-        return str(error)
+        return str(error), 500
 
 @app.route('/topics/<id>/subtopics', methods=['GET'])
 def subtopics(id):
@@ -45,7 +45,7 @@ def subtopics(id):
         response.headers.add('Access-Control-Allow-Origin', '*')
         return response
     except Exception as error:
-        return str(error)
+        return str(error), 500
 
 @app.route('/topics/<topic_id>/subtopics/<subtopic_id>/resources', methods=['GET'])
 def resources(topic_id, subtopic_id):
@@ -55,7 +55,24 @@ def resources(topic_id, subtopic_id):
         response.headers.add('Access-Control-Allow-Origin', '*')
         return response
     except Exception as error:
-        return str(error)
+        return str(error), 500
+
+if __name__ == '__main__':
+    app.run()
+
+@app.route('/topics/<topic_id>/subtopics/<subtopic_id>/resources/<resource_id>/feedback', methods=['POST'])
+def record_feedback(topic_id, subtopic_id, resource_id):
+    try:
+        feedback = request.get_json()
+
+        resource = Resource.query.filter_by(id=resource_id).first()
+        resource.rating = feedback['feedback']
+        db.session.commit
+
+
+        return "200 OK"
+    except Exception as error:
+        return str(error), 500
 
 if __name__ == '__main__':
     app.run()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,4 +1,4 @@
-from flask import Flask, json
+from flask import Flask, json, jsonify
 from app import *
 
 def test_topics_route():
@@ -62,3 +62,42 @@ def test_resources_route():
     data = json.loads(resp.data)
     assert data[0]["name"] == "Array theory"
     assert data[0]["content"] == "Arrays start counting at zero. Trying to access an empty array may throw an out of bounds error"
+
+
+def test_resources_post_feedback():
+    topic = Topic(
+      name="Ruby"
+    )
+    db.session.add(topic)
+    db.session.commit()
+
+    subtopic = SubTopic(
+      name="Arrays",
+      topic_id=topic.id,
+      order=1
+    )
+    db.session.add(subtopic)
+    db.session.commit()
+
+    resource = Resource(
+      name="Array theory",
+      content="Arrays start counting at zero. Trying to access an empty array may throw an out of bounds error",
+      subtopic_id = subtopic.id,
+      rating = 0
+    )
+    db.session.add(resource)
+    db.session.commit()
+
+    request_string = {"feedback": 1}
+
+    with app.test_client() as c:
+      rating_before = Resource.query.filter_by(id=resource.id).first().rating
+      assert rating_before != 1
+
+      url = '/topics/{topic}/subtopics/{subtopic}/resources/{resource}/feedback'.format(topic=topic.id, subtopic=subtopic.id, resource=resource.id)
+      resp = c.post(url, json=request_string)
+
+      assert resp.status == "200 OK"
+
+      rating_after = Resource.query.filter_by(id=resource.id).first().rating
+      assert rating_after == 1


### PR DESCRIPTION
Created a route for giving feedback on a resource. 
The URL is "/topics/:id/subtopics/:id/resources/:id/feedback"
The post method should be called with a json object containing: {"feedback": 1}. The score could in theory be something other than 1. At the moment this will directly update the database, there is no ability to accumulate a score. However if -1 was sent in this could be used to denote negative feedback. 
Also updated all of the routes to return a header of 500 as an error if the code in the route throws an error. 